### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/tfpacker
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/hashicorp/hcl/v2 v2.24.0


### PR DESCRIPTION
## Summary
- Bump Go version in `go.mod` from `1.26.1` to `1.26.5`.
- Go 1.26.5 (released 2026-07-07) includes security fixes to `crypto/tls` and `os`.

## Verification
- `go mod tidy`: clean, no changes to `go.sum`.
- `go test ./...`: all packages pass (macOS/arm64, go1.26.5 toolchain).